### PR TITLE
Potential fix for code scanning alert no. 13: Overly permissive regular expression range

### DIFF
--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -176,7 +176,7 @@ export class LoopDetectionService {
       /(^|\n)\s*[*-+]\s/.test(content) || /(^|\n)\s*\d+\.\s/.test(content);
     const hasHeading = /(^|\n)#+\s/.test(content);
     const hasBlockquote = /(^|\n)>\s/.test(content);
-    const isDivider = /^[+-_=*\u2500-\u257F]+$/.test(content);
+    const isDivider = /^[+\-_=*\u2500-\u257F]+$/.test(content);
 
     if (
       numFences ||


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/13](https://github.com/se2026/gemini-cli/security/code-scanning/13)

The best way to fix this problem is to make the regular expression character class more explicit in what characters are allowed. Instead of allowing a range from `+` to `_`, list the intended visible divider characters individually, and ensure the dash is included as a literal either by escaping (`\-`) or by placing it at the beginning or end of the character class. The Unicode box drawing range may be retained as is. Specifically, change the regex on line 179 so that it only matches the intended divider symbols and box drawing characters, for example: `/^[+\-_=*\u2500-\u257F]+$/`. To do this, edit line 179 to escape the dash: `[+\-_=*\u2500-\u257F]`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
