### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -155,10 +155,19 @@ ${textContent}
     // Perform GitHub URL conversion here to differentiate between user-provided
     // URL and the actual URL to be fetched.
     const urls = extractUrls(this.params.prompt).map((url) => {
-      if (url.includes('github.com') && url.includes('/blob/')) {
-        return url
-          .replace('github.com', 'raw.githubusercontent.com')
-          .replace('/blob/', '/');
+      try {
+        const parsed = new URL(url);
+        if (
+          parsed.hostname === 'github.com' &&
+          parsed.pathname.includes('/blob/')
+        ) {
+          // Safe: only rewrite actual GitHub blob URLs.
+          return url
+            .replace('github.com', 'raw.githubusercontent.com')
+            .replace('/blob/', '/');
+        }
+      } catch {
+        // Not a valid URL; leave unchanged.
       }
       return url;
     });


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/12](https://github.com/se2026/gemini-cli/security/code-scanning/12)

The problem should be fixed by parsing each extracted URL before making any decisions based on its host. Specifically, instead of checking `url.includes('github.com')`, parse the URL (e.g., using the `URL` constructor available in Node.js) and check whether its hostname is exactly `'github.com'` and its path matches the blob pattern. If you want to match subdomains or additional variants, enumerate them explicitly in an array of allowed hosts. This change should be made only in the relevant block (lines 157-163). An import for the `URL` constructor is not required in Node.js/TypeScript environments. The new logic should use `try...catch` for invalid URLs and default to leaving those unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
