### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,4 +1,6 @@
 name: 'Eval'
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/2](https://github.com/se2026/gemini-cli/security/code-scanning/2)

To remedy the problem, the workflow should explicitly define a `permissions` key restricting the `GITHUB_TOKEN` to the least required privilege, which for most workflows should be `contents: read` unless more is required. The best way to implement this is to add a `permissions: contents: read` block at the top-level of the workflow file—after the `name` and before the `on` key—so that it applies globally to all jobs. No further methods, imports, or complex definitions are needed; this is a simple YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
