### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: 'E2E Tests'
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/1](https://github.com/se2026/gemini-cli/security/code-scanning/1)

The best way to fix the problem is to explicitly add a `permissions` key at the top level of the workflow (after the `name` and before `on`), specifying the minimum required permissions. Since the E2E test workflow as written only seems to require read access (e.g., for checking out code), you should set the permissions to `contents: read`. If a job inside the workflow needs broader permissions in the future, a more permissive `permissions` block can be added at the job level. For now, add the following to the YAML:

```yaml
permissions:
  contents: read
```

This should be inserted after the workflow `name:` (line 1) and before the `on:` (line 3) section in `.github/workflows/e2e.yml`. No further imports, methods, or variable definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
