### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -13,6 +13,8 @@ jobs:
   calculate-versions:
     name: 'Calculate Versions and Plan'
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
     outputs:
       STABLE_VERSION: '${{ steps.versions.outputs.STABLE_VERSION }}'
       STABLE_SHA: '${{ steps.versions.outputs.STABLE_SHA }}'


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/17](https://github.com/se2026/gemini-cli/security/code-scanning/17)

To fix the problem, add an explicit `permissions` block to the `calculate-versions` job region in `.github/workflows/promote-release.yml`. The block should restrict permissions as much as possible, starting with `contents: read`, since this job does not perform any write operations on the repository; it only checks out code and runs read-only scripts. No other permission is needed for issues, pull-requests, or other resources. The block should be indented and placed after the `runs-on:` line and before the `outputs:` line in the `calculate-versions` job definition.

No new methods, imports, or definitions are required—just the addition of the proper permissions block in the specified region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
