### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,4 +1,6 @@
 name: 'Nightly Release'
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/16](https://github.com/se2026/gemini-cli/security/code-scanning/16)

To remediate this issue, add an explicit `permissions` block to the workflow that specifies the minimal required privileges for safe execution. Since the workflow involves publishing releases (modifying release objects on GitHub), it likely needs `contents: write` and possibly `pull-requests: write` if it interacts with PRs, but if it only pushes tags/releases, `contents: write` should suffice. The best starting point is to add `permissions: contents: write` at the workflow root level (directly below the `name:` and above or below `on:`), which will limit all jobs to only the ability to write repository contents (e.g., tags, releases, commits). If additional access (like `packages` or `issues`) is required by actions, those can be added as needed. This change should be made at the top of `.github/workflows/nightly-release.yml`, ideally just after the `name:` statement.

No new imports or code is required, only a single block addition to the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
