### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -183,7 +183,7 @@ export async function openDiff(
         return new Promise((resolve, reject) => {
           const childProcess = spawn(diffCommand.command, diffCommand.args, {
             stdio: 'inherit',
-            shell: true,
+            shell: false,
           });
 
           childProcess.on('close', (code) => {


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/3](https://github.com/se2026/gemini-cli/security/code-scanning/3)

To fix the vulnerability, we must prevent shell injection when launching external processes, especially when the input may contain untrusted or unsafe characters. When using `spawn`, avoid setting `{shell: true}` unless absolutely needed (which is rarely required for launching GUI editors). Change `{shell: true}` to `{shell: false}` (the Node.js default), so argument strings are passed directly to the executable, bypassing the shell's interpretation. Additionally, ensure that `diffCommand.command` and all entries in `diffCommand.args` are not tainted with dangerous shell metacharacters if needed. In most cases, launching editors via spawn with `shell: false` suffices, and arguments do not need extra escaping.

Edits required: In `openDiff`, at the `spawn` call (lines 184-186), change `{stdio: 'inherit', shell: true}` to `{stdio: 'inherit', shell: false}`.

No extra imports or library dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
