### PR TITLE
Potential fix for code scanning alert no. 10: Shell command built from environment values

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -374,19 +374,22 @@ export async function start_sandbox(
         console.error('building sandbox ...');
         const gcRoot = gcPath.split('/packages/')[0];
         // if project folder has sandbox.Dockerfile under project settings folder, use that
-        let buildArgs = '';
+        const buildArgs: string[] = ['-s'];
         const projectSandboxDockerfile = path.join(
           SETTINGS_DIRECTORY_NAME,
           'sandbox.Dockerfile',
         );
         if (isCustomProjectSandbox) {
           console.error(`using ${projectSandboxDockerfile} for sandbox`);
-          buildArgs += `-f ${path.resolve(projectSandboxDockerfile)} -i ${image}`;
+          buildArgs.push('-f', path.resolve(projectSandboxDockerfile), '-i', image);
         }
-        execSync(
-          `cd ${gcRoot} && node scripts/build_sandbox.js -s ${buildArgs}`,
+        // Use execFileSync to avoid shell interpretation, set cwd for directory
+        require('child_process').execFileSync(
+          'node',
+          ['scripts/build_sandbox.js', ...buildArgs],
           {
             stdio: 'inherit',
+            cwd: gcRoot,
             env: {
               ...process.env,
               GEMINI_SANDBOX: config.command, // in case sandbox is enabled via flags (see config.ts under cli package)


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/10](https://github.com/se2026/gemini-cli/security/code-scanning/10)

The problem stems from injecting the uncontrolled `gcRoot` variable into an interpolated shell command, which is run via `execSync`. To fix this, avoid constructing shell commands via concatenation, and pass command arguments positionally so that the shell never interprets the file path as executable code. Instead of `execSync('cd ... && node ...')`, use the `spawnSync` or `execFileSync` method, and set the working directory using the relevant option (`cwd`).  
Specifically:

- Use `node scripts/build_sandbox.js` as the command with arguments (`['-s', ...]`).
- Set `cwd: gcRoot` in the options to run the command in the intended directory.
- Eliminate the shell-specific constructs (`cd ... &&`) so that no shell evaluation occurs.
- Ensure all arguments (especially those from `buildArgs`) are passed as elements of the `args` array, avoiding string interpolation.

This change should be applied to line 387-395, and you may need to refactor `buildArgs` to be an array (rather than a string).  
Also, confirm that any variables passed as arguments (e.g., from `path.resolve` or `image`) are safe as arguments.

No new imports are necessary; `spawnSync` and `execFileSync` are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
