### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -203,15 +203,14 @@ export async function openDiff(
       case 'emacs':
       case 'neovim': {
         // Use execSync for terminal-based editors
-        const command =
-          process.platform === 'win32'
-            ? `${diffCommand.command} ${diffCommand.args.join(' ')}`
-            : `${diffCommand.command} ${diffCommand.args.map((arg) => `"${arg}"`).join(' ')}`;
         try {
-          execSync(command, {
+          const result = spawnSync(diffCommand.command, diffCommand.args, {
             stdio: 'inherit',
             encoding: 'utf8',
           });
+          if (result.error) {
+            throw result.error;
+          }
         } catch (e) {
           console.error('Error in onEditorClose callback:', e);
         } finally {


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/8](https://github.com/se2026/gemini-cli/security/code-scanning/8)

The best way to fix this unsafe shell command construction is to avoid invoking a shell with string-concatenated (and possibly untrusted) arguments. Instead of using `execSync` to run a concatenated string, directly run the executable with arguments via `spawnSync`, supplying both the command and its arguments as arrays. This approach eliminates all risks from shell metacharacter interpretation and quoting issues. 

In this code:
- For terminal-based editors (`vim`, `neovim`, `emacs`), replace the `execSync(command, ...)` (where `command` is a string containing all arguments) with `spawnSync(diffCommand.command, diffCommand.args, { stdio: 'inherit', encoding: 'utf8' })`.
- Remove the concatenated command string construction at lines 206–209.
- No changes to existing editor launching logic are needed, as the arguments are already available as an array (`diffCommand.args`).
- Only the region under `case 'vim': case 'emacs': case 'neovim'` between lines 205–220 (and any associated command string construction) should be altered.

No additional dependencies are required as `spawnSync` is available in Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
