### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -81,10 +81,15 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     let url = urls[0];
 
     // Convert GitHub blob URL to raw URL
-    if (url.includes('github.com') && url.includes('/blob/')) {
-      url = url
-        .replace('github.com', 'raw.githubusercontent.com')
-        .replace('/blob/', '/');
+    try {
+      const parsedUrl = new URL(url);
+      if (parsedUrl.hostname === 'github.com' && parsedUrl.pathname.includes('/blob/')) {
+        url = url
+          .replace('github.com', 'raw.githubusercontent.com')
+          .replace('/blob/', '/');
+      }
+    } catch (e) {
+      // If the URL is invalid, do not attempt the conversion
     }
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/11](https://github.com/se2026/gemini-cli/security/code-scanning/11)

The best way to fix this problem is to parse the URL string using the built-in `URL` class, and check its `.hostname` property to ensure it matches `github.com` exactly. Additionally, if the code intends to support subdomains (like `www.github.com`), we may consider this, but the most robust and least permissive fix is to check precisely `github.com`. This change should be applied in the `executeFallback` method of the `WebFetchToolInvocation` class (lines 81–88). In particular, replace the substring check on line 84 with a check on the parsed URL's hostname property. You may need to handle invalid URLs with a try/catch or pattern check. No new imports are needed as the global `URL` constructor is available in Node.js >=10+ and in TypeScript targets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
