### PR TITLE
Potential fix for code scanning alert no. 20: Prototype-polluting function

### DIFF
--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -45,6 +45,9 @@ function applyUpdates(
   const result = current;
 
   for (const key of Object.getOwnPropertyNames(updates)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
     const value = updates[key];
     if (
       typeof value === 'object' &&


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/gemini-cli/security/code-scanning/20](https://github.com/se2026/gemini-cli/security/code-scanning/20)

To fix the prototype pollution vulnerability in `applyUpdates`, we should prevent the function from copying or assigning the dangerous keys `__proto__`, `constructor`, and `prototype`. Specifically, we should skip any property whose key is either `__proto__` or `constructor`, and explicitly prevent dangerous deep paths like `constructor.prototype`. The best practice is to check the key at each level and simply `continue` the loop for those dangerous keys before making any assignment. This can be done by adding a conditional statement in the loop of `applyUpdates`. No new dependencies are needed. All changes are contained within the `applyUpdates` function in the file `packages/cli/src/utils/commentJson.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
